### PR TITLE
Extend verification chapter with formal methods

### DIFF
--- a/docs/03-verification/01-duration-terms.adoc
+++ b/docs/03-verification/01-duration-terms.adoc
@@ -17,6 +17,6 @@ ifeval::["{suffix}" == "EMBEDDEDSEC"]
 endif::[]
 
 === Terms and Principles
-Dynamic Testing, Static Analysis, Verification, Validation
+Dynamic Testing, Formal Methods, Static Analysis, Verification, Validation
 
 // end::EN[]

--- a/docs/03-verification/02-learning-goals.adoc
+++ b/docs/03-verification/02-learning-goals.adoc
@@ -21,8 +21,8 @@ tbd.
 // tag::EN[]
 [[LG-3-1]]
 ==== LG 3-1: Verification Goals
-Participants understand the goals of security testing.
-Participants know classifications of security testing:
+Participants understand the goals of security verification.
+Participants know classifications of security Verification methods:
 
 * Dynamic Application Security Testing
 * Static Application Security Testing

--- a/docs/03-verification/references.adoc
+++ b/docs/03-verification/references.adoc
@@ -1,5 +1,7 @@
 === {references}
 
+<<isaqbfm>>, <<istqbgloassry>>
+
 // tag::DE[]
 // silence asciidoctor warnings
 // end::DE[]

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -19,6 +19,11 @@ ifeval::["{suffix}" == "EMBEDDEDSEC"]
 
 - [[[fernandez13, Fernandez-Buglioni 2013]]] Fernandez-Buglioni, F: Security Patterns in Practice: Designing Secure Architectures Using Software Patterns. Wiley, 2013
 
+**I**
+
+- [[[isaqbfm, iSAQB AL Formal Methods]]] iSAQB e.V. : The CPSA Advanced Level Module Formal Methods. iSAQB e.V., 2024
+- [[[istqbgloassry, iSTQB Glossary]]] iSTQB: iSTQB Glossary. iSTQB, https://glossary.istqb.org/en_US/home
+
 **O**
 
 - [[[owasptop10, OWASP Top 10]]] Open Web Application Security Project: Top 10 Web Application Security Risks. https://owasp.org/www-project-top-ten/, 2021


### PR DESCRIPTION
To address the feedback in #2 the term formal methods is added, misleading usage of the term testing is changed to use verification and additional references for formal methods and definitions are added.